### PR TITLE
Attempt to fix cdrom image loading crash by replacing dev->ops->get_last_block with image_get_last_block.

### DIFF
--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -2655,7 +2655,7 @@ image_open(cdrom_t *dev, const char *path)
 
         if (ret > 0) {
             if (img->is_dvd == 2) {
-                uint32_t lb = dev->ops->get_last_block(img);
+                uint32_t lb = image_get_last_block(img); /* Should be safer than previous way of doing it? */
                 img->is_dvd = (lb >= 524287);    /* Minimum 1 GB total capacity as threshold for DVD. */
             }
 


### PR DESCRIPTION
Summary
=======
This is a fix to bug #5829. Confirmed to fix the crash, though I have not tested it further.

Checklist
=========
* [x] Closes #5829
* [ ] I have discussed this with core contributors already (I tried to, but nobody was awake apparently :P)
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
See discussion on the Discord re a backtrace and where my potential fix came from.
